### PR TITLE
Api/issue-33 여행지 저장 api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
-application.yml
-application-dev.yml
-application-local.yml
-application-test.yml
+*.yml
 LetsTravelDevDB.sql
 LetsTravelLocalDB.sql
 

--- a/src/main/java/com/letsTravel/LetsTravel/controller/PlaceController.java
+++ b/src/main/java/com/letsTravel/LetsTravel/controller/PlaceController.java
@@ -1,11 +1,14 @@
 package com.letsTravel.LetsTravel.controller;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.letsTravel.LetsTravel.domain.PlaceCreateDTO;
+import com.letsTravel.LetsTravel.domain.GoogleMapsPlace;
 import com.letsTravel.LetsTravel.service.PlaceService;
 
 @RestController
@@ -21,7 +24,7 @@ public class PlaceController {
 	
 	// 뭘 반환하지
 	@PostMapping("/place")
-	public int createPlace(PlaceCreateDTO placeCreateDTO) {
-		return placeService.createPlace(placeCreateDTO);
+	public int createPlaces(@RequestBody List<GoogleMapsPlace> GoogleMapsPlaceList) {
+		return placeService.createPlaces(GoogleMapsPlaceList);
 	}
 }

--- a/src/main/java/com/letsTravel/LetsTravel/controller/PlaceController.java
+++ b/src/main/java/com/letsTravel/LetsTravel/controller/PlaceController.java
@@ -1,0 +1,27 @@
+package com.letsTravel.LetsTravel.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.letsTravel.LetsTravel.domain.PlaceCreateDTO;
+import com.letsTravel.LetsTravel.service.PlaceService;
+
+@RestController
+@RequestMapping(value = "/api")
+public class PlaceController {
+	
+	private final PlaceService placeService;
+	
+	@Autowired
+	public PlaceController(PlaceService placeService) {
+		this.placeService = placeService;
+	}
+	
+	// 뭘 반환하지
+	@PostMapping("/place")
+	public int createPlace(PlaceCreateDTO placeCreateDTO) {
+		return placeService.createPlace(placeCreateDTO);
+	}
+}

--- a/src/main/java/com/letsTravel/LetsTravel/domain/CityCreateDTO.java
+++ b/src/main/java/com/letsTravel/LetsTravel/domain/CityCreateDTO.java
@@ -1,0 +1,17 @@
+package com.letsTravel.LetsTravel.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class CityCreateDTO {
+
+	private String countryCode;
+	private String cityName;
+	private String cityLanguageCode;
+}

--- a/src/main/java/com/letsTravel/LetsTravel/domain/CityDTO.java
+++ b/src/main/java/com/letsTravel/LetsTravel/domain/CityDTO.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 public class CityDTO {
 
 	private int id;
+	private String countryCode;
 	private String cityName;
 	private String cityNameTranslated;
 }

--- a/src/main/java/com/letsTravel/LetsTravel/domain/GoogleMapsPlace.java
+++ b/src/main/java/com/letsTravel/LetsTravel/domain/GoogleMapsPlace.java
@@ -14,6 +14,5 @@ public class GoogleMapsPlace {
 	private PlaceCreateDTO placeDetail;
 	private List<CityCreateDTO> cities;
 	private List<String> types;
-	private String primaryTypeDisplayName;
-	private String primaryType;
+	private TypeTranslateDTO primaryTypeDetail;
 }

--- a/src/main/java/com/letsTravel/LetsTravel/domain/GoogleMapsPlace.java
+++ b/src/main/java/com/letsTravel/LetsTravel/domain/GoogleMapsPlace.java
@@ -1,0 +1,19 @@
+package com.letsTravel.LetsTravel.domain;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class GoogleMapsPlace {
+	
+	private PlaceCreateDTO placeDetail;
+	private List<CityCreateDTO> cities;
+	private List<String> types;
+	private String primaryTypeDisplayName;
+	private String primaryType;
+}

--- a/src/main/java/com/letsTravel/LetsTravel/domain/Location.java
+++ b/src/main/java/com/letsTravel/LetsTravel/domain/Location.java
@@ -1,0 +1,14 @@
+package com.letsTravel.LetsTravel.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class Location {
+
+	private float latitude;
+	private float longitude;
+}

--- a/src/main/java/com/letsTravel/LetsTravel/domain/PlaceCreateDTO.java
+++ b/src/main/java/com/letsTravel/LetsTravel/domain/PlaceCreateDTO.java
@@ -1,0 +1,22 @@
+package com.letsTravel.LetsTravel.domain;
+
+import java.sql.Date;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PlaceCreateDTO {
+	
+	private String placeId;
+	private String placeName;
+	private String placeFormattedAddress;
+	private String cityName;
+	private String cityLanguageCode;
+	private String countryCode;
+	private float placeLatitude;
+	private float placeLongitude;
+	private String placeGmapUri;
+	private Date placeInsertDate;
+}

--- a/src/main/java/com/letsTravel/LetsTravel/domain/PlaceCreateDTO.java
+++ b/src/main/java/com/letsTravel/LetsTravel/domain/PlaceCreateDTO.java
@@ -1,22 +1,18 @@
 package com.letsTravel.LetsTravel.domain;
 
-import java.sql.Date;
-
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class PlaceCreateDTO {
-	
-	private String placeId;
-	private String placeName;
-	private String placeFormattedAddress;
-	private String cityName;
-	private String cityLanguageCode;
-	private String countryCode;
-	private float placeLatitude;
-	private float placeLongitude;
-	private String placeGmapUri;
-	private Date placeInsertDate;
+
+	private String id;
+	private String displayName;
+	private String formattedAddress;
+	private Location location;
+	private String googleMapsUri;
+
 }

--- a/src/main/java/com/letsTravel/LetsTravel/domain/TypeTranslateDTO.java
+++ b/src/main/java/com/letsTravel/LetsTravel/domain/TypeTranslateDTO.java
@@ -1,0 +1,14 @@
+package com.letsTravel.LetsTravel.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class TypeTranslateDTO {
+
+	private String primaryTypeDisplayName;
+	private String primaryType;
+}

--- a/src/main/java/com/letsTravel/LetsTravel/repository/CityRepository.java
+++ b/src/main/java/com/letsTravel/LetsTravel/repository/CityRepository.java
@@ -2,9 +2,11 @@ package com.letsTravel.LetsTravel.repository;
 
 import java.util.List;
 
+import com.letsTravel.LetsTravel.domain.CityCreateDTO;
 import com.letsTravel.LetsTravel.domain.CityDTO;
 
 public interface CityRepository {
 
 	public List<CityDTO> findCities(String countryCode);
+	public int addCity(CityCreateDTO cityCreateDTO);
 }

--- a/src/main/java/com/letsTravel/LetsTravel/repository/JdbcTemplateCityRepository.java
+++ b/src/main/java/com/letsTravel/LetsTravel/repository/JdbcTemplateCityRepository.java
@@ -10,6 +10,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 
+import com.letsTravel.LetsTravel.domain.CityCreateDTO;
 import com.letsTravel.LetsTravel.domain.CityDTO;
 
 @Repository
@@ -23,18 +24,27 @@ public class JdbcTemplateCityRepository implements CityRepository {
 
 	@Override
 	public List<CityDTO> findCities(String countryCode) {
-		return jdbcTemplate.query("SELECT C.City_seq, C.City_name, C.City_name_translated FROM CITY C WHERE C.Country_code = ?", 
+		return jdbcTemplate.query(
+				"SELECT C.City_seq, C.City_name, C.City_name_translated FROM CITY C WHERE C.Country_code = ?",
 				new RowMapper<CityDTO>() {
-			@Override
-			public CityDTO mapRow(ResultSet rs, int rowNum) throws SQLException {
-				CityDTO cityDTO = new CityDTO();
-				cityDTO.setId(rs.getInt(1));
-				cityDTO.setCountryCode(countryCode);
-				cityDTO.setCityName(rs.getString(2));
-				cityDTO.setCityNameTranslated(rs.getString(3));
-				return cityDTO;
-			}
-		},
-		countryCode);
+					@Override
+					public CityDTO mapRow(ResultSet rs, int rowNum) throws SQLException {
+						CityDTO cityDTO = new CityDTO();
+						cityDTO.setId(rs.getInt(1));
+						cityDTO.setCountryCode(countryCode);
+						cityDTO.setCityName(rs.getString(2));
+						cityDTO.setCityNameTranslated(rs.getString(3));
+						return cityDTO;
+					}
+				}, countryCode);
+	}
+
+	@Override
+	public int addCity(CityCreateDTO cityCreateDTO) {
+		String sql = "INSERT INTO City(Country_code, City_name"
+				+ (cityCreateDTO.getCityLanguageCode().equals("ko") ? "_translated" : "")
+				+ ") SELECT ?, ? FROM DUAL WHERE NOT EXISTS (SELECT City_seq FROM City WHERE City_name"
+				+ (cityCreateDTO.getCityLanguageCode().equals("ko") ? "_translated" : "") + " = ?);";
+		return jdbcTemplate.update(sql, cityCreateDTO.getCountryCode(), cityCreateDTO.getCityName(), cityCreateDTO.getCityName());
 	}
 }

--- a/src/main/java/com/letsTravel/LetsTravel/repository/JdbcTemplateCityRepository.java
+++ b/src/main/java/com/letsTravel/LetsTravel/repository/JdbcTemplateCityRepository.java
@@ -2,7 +2,6 @@ package com.letsTravel.LetsTravel.repository;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.sql.DataSource;
@@ -30,6 +29,7 @@ public class JdbcTemplateCityRepository implements CityRepository {
 			public CityDTO mapRow(ResultSet rs, int rowNum) throws SQLException {
 				CityDTO cityDTO = new CityDTO();
 				cityDTO.setId(rs.getInt(1));
+				cityDTO.setCountryCode(countryCode);
 				cityDTO.setCityName(rs.getString(2));
 				cityDTO.setCityNameTranslated(rs.getString(3));
 				return cityDTO;

--- a/src/main/java/com/letsTravel/LetsTravel/repository/JdbcTemplatePlaceRepository.java
+++ b/src/main/java/com/letsTravel/LetsTravel/repository/JdbcTemplatePlaceRepository.java
@@ -1,0 +1,24 @@
+package com.letsTravel.LetsTravel.repository;
+
+import javax.sql.DataSource;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import com.letsTravel.LetsTravel.domain.PlaceCreateDTO;
+
+@Repository
+public class JdbcTemplatePlaceRepository implements PlaceRepository{
+
+	private final JdbcTemplate jdbcTemplate;
+	
+	public JdbcTemplatePlaceRepository(DataSource dataSource) {
+		this.jdbcTemplate = new JdbcTemplate(dataSource);
+	}
+	
+	@Override
+	public int addPlace(PlaceCreateDTO placeCreateDTO) {
+		return 1;
+	}
+
+}

--- a/src/main/java/com/letsTravel/LetsTravel/repository/JdbcTemplatePlaceRepository.java
+++ b/src/main/java/com/letsTravel/LetsTravel/repository/JdbcTemplatePlaceRepository.java
@@ -5,20 +5,26 @@ import javax.sql.DataSource;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
+import com.letsTravel.LetsTravel.domain.GoogleMapsPlace;
 import com.letsTravel.LetsTravel.domain.PlaceCreateDTO;
 
 @Repository
-public class JdbcTemplatePlaceRepository implements PlaceRepository{
+public class JdbcTemplatePlaceRepository implements PlaceRepository {
 
 	private final JdbcTemplate jdbcTemplate;
-	
+
 	public JdbcTemplatePlaceRepository(DataSource dataSource) {
 		this.jdbcTemplate = new JdbcTemplate(dataSource);
 	}
-	
+
 	@Override
 	public int addPlace(PlaceCreateDTO placeCreateDTO) {
-		return 1;
+		String sql = "INSERT INTO Place(Place_id, Place_name, Place_formatted_address, Place_latitude, Place_longitude, Place_gmap_uri, Place_insert_date) "
+				+ "VALUES(?, ?, ?, ?, ?, ?, curdate()) " + "ON DUPLICATE KEY UPDATE Place_insert_date = curdate();";
+		return jdbcTemplate.update(sql, placeCreateDTO.getId(), placeCreateDTO.getDisplayName(),
+				placeCreateDTO.getFormattedAddress(), placeCreateDTO.getLocation().getLatitude(),
+				placeCreateDTO.getLocation().getLongitude(), placeCreateDTO.getGoogleMapsUri());
+
 	}
 
 }

--- a/src/main/java/com/letsTravel/LetsTravel/repository/JdbcTemplateTypeRepository.java
+++ b/src/main/java/com/letsTravel/LetsTravel/repository/JdbcTemplateTypeRepository.java
@@ -1,0 +1,25 @@
+package com.letsTravel.LetsTravel.repository;
+
+import javax.sql.DataSource;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import com.letsTravel.LetsTravel.domain.TypeTranslateDTO;
+
+@Repository
+public class JdbcTemplateTypeRepository implements TypeRepository {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public JdbcTemplateTypeRepository(DataSource dataSource) {
+		this.jdbcTemplate = new JdbcTemplate(dataSource);
+	}
+
+	@Override
+	public int modifyTypeNameTranslated(TypeTranslateDTO typeTranslateDTO) {
+		String sql = "UPDATE Type SET Type_name_translated = ? WHERE Type_name = ?;";
+		return jdbcTemplate.update(sql, typeTranslateDTO.getPrimaryTypeDisplayName(), typeTranslateDTO.getPrimaryType());
+	}
+
+}

--- a/src/main/java/com/letsTravel/LetsTravel/repository/PlaceRepository.java
+++ b/src/main/java/com/letsTravel/LetsTravel/repository/PlaceRepository.java
@@ -1,0 +1,9 @@
+package com.letsTravel.LetsTravel.repository;
+
+import com.letsTravel.LetsTravel.domain.PlaceCreateDTO;
+
+public interface PlaceRepository {
+
+	// 뭘 반환할까
+	public int addPlace(PlaceCreateDTO placeCreateDTO);
+}

--- a/src/main/java/com/letsTravel/LetsTravel/repository/TypeRepository.java
+++ b/src/main/java/com/letsTravel/LetsTravel/repository/TypeRepository.java
@@ -1,0 +1,8 @@
+package com.letsTravel.LetsTravel.repository;
+
+import com.letsTravel.LetsTravel.domain.TypeTranslateDTO;
+
+public interface TypeRepository {
+
+	public int modifyTypeNameTranslated(TypeTranslateDTO typeTranslateDTO);
+}

--- a/src/main/java/com/letsTravel/LetsTravel/service/CityService.java
+++ b/src/main/java/com/letsTravel/LetsTravel/service/CityService.java
@@ -5,13 +5,14 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import com.letsTravel.LetsTravel.domain.CityCreateDTO;
 import com.letsTravel.LetsTravel.domain.CityDTO;
 import com.letsTravel.LetsTravel.repository.CityRepository;
 
 @Service
 public class CityService {
 
-	private CityRepository cityRepository;
+	private final CityRepository cityRepository;
 	
 	@Autowired
 	public CityService(CityRepository cityRepository) {
@@ -21,4 +22,9 @@ public class CityService {
 	public List<CityDTO> findCities(String countryCode) {
 		return cityRepository.findCities(countryCode);
 	}
+
+	public int addCity(CityCreateDTO cityCreateDTO) {
+		return cityRepository.addCity(cityCreateDTO);
+	}
+
 }

--- a/src/main/java/com/letsTravel/LetsTravel/service/PlaceService.java
+++ b/src/main/java/com/letsTravel/LetsTravel/service/PlaceService.java
@@ -1,0 +1,34 @@
+package com.letsTravel.LetsTravel.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.letsTravel.LetsTravel.domain.CityCreateDTO;
+import com.letsTravel.LetsTravel.domain.PlaceCreateDTO;
+import com.letsTravel.LetsTravel.repository.PlaceRepository;
+
+@Service
+public class PlaceService {
+
+	private final PlaceRepository placeRepository;
+	private final CityService cityService;
+
+	@Autowired
+	public PlaceService(PlaceRepository placeRepository, CityService cityService) {
+		this.placeRepository = placeRepository;
+		this.cityService = cityService;
+	}
+
+	public int createPlace(PlaceCreateDTO placeCreateDTO) {
+		// City가 저장되어 있는지 확인
+		CityCreateDTO cityCreateDTO = CityCreateDTO.builder()
+				.countryCode(placeCreateDTO.getCountryCode())
+				.cityName(placeCreateDTO.getCityName())
+				.cityLanguageCode(placeCreateDTO.getCityLanguageCode())
+				.build();
+		cityService.addCity(cityCreateDTO);
+		
+		return 0;
+	}
+
+}

--- a/src/main/java/com/letsTravel/LetsTravel/service/PlaceService.java
+++ b/src/main/java/com/letsTravel/LetsTravel/service/PlaceService.java
@@ -8,17 +8,20 @@ import org.springframework.stereotype.Service;
 import com.letsTravel.LetsTravel.domain.CityCreateDTO;
 import com.letsTravel.LetsTravel.domain.GoogleMapsPlace;
 import com.letsTravel.LetsTravel.repository.PlaceRepository;
+import com.letsTravel.LetsTravel.repository.TypeRepository;
 
 @Service
 public class PlaceService {
 
 	private final PlaceRepository placeRepository;
 	private final CityService cityService;
+	private final TypeRepository typeRepository;
 
 	@Autowired
-	public PlaceService(PlaceRepository placeRepository, CityService cityService) {
+	public PlaceService(PlaceRepository placeRepository, CityService cityService, TypeRepository typeRepository) {
 		this.placeRepository = placeRepository;
 		this.cityService = cityService;
+		this.typeRepository = typeRepository;
 	}
 
 	public int createPlaces(List<GoogleMapsPlace> GoogleMapsPlaceList) {
@@ -35,6 +38,7 @@ public class PlaceService {
 			result += placeRepository.addPlace(GoogleMapsPlaceList.get(i).getPlaceDetail());
 			
 			// Type 번역
+			typeRepository.modifyTypeNameTranslated(GoogleMapsPlaceList.get(i).getPrimaryTypeDetail());
 		}
 
 		return result;

--- a/src/main/java/com/letsTravel/LetsTravel/service/PlaceService.java
+++ b/src/main/java/com/letsTravel/LetsTravel/service/PlaceService.java
@@ -1,10 +1,12 @@
 package com.letsTravel.LetsTravel.service;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.letsTravel.LetsTravel.domain.CityCreateDTO;
-import com.letsTravel.LetsTravel.domain.PlaceCreateDTO;
+import com.letsTravel.LetsTravel.domain.GoogleMapsPlace;
 import com.letsTravel.LetsTravel.repository.PlaceRepository;
 
 @Service
@@ -19,16 +21,23 @@ public class PlaceService {
 		this.cityService = cityService;
 	}
 
-	public int createPlace(PlaceCreateDTO placeCreateDTO) {
-		// City가 저장되어 있는지 확인
-		CityCreateDTO cityCreateDTO = CityCreateDTO.builder()
-				.countryCode(placeCreateDTO.getCountryCode())
-				.cityName(placeCreateDTO.getCityName())
-				.cityLanguageCode(placeCreateDTO.getCityLanguageCode())
-				.build();
-		cityService.addCity(cityCreateDTO);
+	public int createPlaces(List<GoogleMapsPlace> GoogleMapsPlaceList) {
 		
-		return 0;
+		int result = 0;
+		
+		for (int i = 0; i < GoogleMapsPlaceList.size(); i++) {
+			// City 저장(없으면 저장, 있으면 패스)
+			List<CityCreateDTO> cityCreateDTOList = GoogleMapsPlaceList.get(i).getCities();
+			for (int j = 0; j < cityCreateDTOList.size(); j++)
+				cityService.addCity(cityCreateDTOList.get(i));
+			
+			// Place 저장
+			result += placeRepository.addPlace(GoogleMapsPlaceList.get(i).getPlaceDetail());
+			
+			// Type 번역
+		}
+
+		return result;
 	}
 
 }


### PR DESCRIPTION
## 여행지 저장 API
- 사용법: POST /api/place
- Place를 삽입하면서 등록되지 않은 City가 있다면 추가, Type_name 번역도 겸사겸사 함
----
#### Google Map Places API로 받을 파라미터
- places.id, 
- places.addressComponents,
- places.displayName,
- places.formattedAddress,
- places.googleMapsUri,
- places.location,
- places.primaryTypeDisplayName,
- places.types // political 있으면 보내지 마셈, establishment랑 point_of_interest만 있으면 보내지 마셈

#### 서버로 보낼 JSON(raw) 파라미터
- placeDetail{id, displayName, formattedAddress, location{latitude, longitude}, googleMapsUri}
- cities[{countryCode, cityName, cityLanguageCode}] // addressComponents에 해당하는 부분 + 배열임
  - countryCode: addressComponents의 country 부분의 shortText
  - cityName: administrative_area_level_1, administrative_area_level_2인 것만 보내주셈
  - cityLanguageCode: administrative_area_level_1, administrative_area_level_2의 languageCode
- types[] // political 있으면 보내지 마셈, establishment point_of_interest만 있으면 보내지 마셈
- primaryTypeDetail{primaryTypeDisplayName, primaryType}

##### 사용예시 // Postman 가서 Beautify하는 게 나을 듯
``
[
    {
        "placeDetail": {
            "id": "asdfasdf",
            "displayName": "마늘요리",
            "formattedAddress": "대구 누리관",
            "location": {
                "latitude": 1.1,
                "longitude": -0.3
            },
            "googleMapsUri": "localhost:8080/하와왕"
        },
        "cities": [
            {
                "countryCode": "kr",
                "cityName": "대구광역시",
                "cityLanguageCode": "ko"
            }
        ],
        "types": [
            "tourist_attraction",
            "food"
        ],
        "primaryTypeDetail": {
            "primaryTypeDisplayName": "관광 명소",
            "primaryType": "tourist_attraction"
        }
    }
]
``